### PR TITLE
typo: fix link to open source repo

### DIFF
--- a/src/views/AppCarburant.vue
+++ b/src/views/AppCarburant.vue
@@ -284,7 +284,7 @@
                         <i> Celles-ci sont mises à disposition par le Ministère de l'Économie, des Finances et de la Souveraineté industrielle et numérique.
                         Pour plus d'informations <a href="https://www.prix-carburants.gouv.fr/"><u>rendez-vous sur le site officiel.</u></a></i>
                         <br />
-                        <i>Cette visualisation a été créée par le département Etalab de <a href="https://www.numerique.gouv.fr/"><u>la Direction Interministérielle du Numérique (DINUM)</u></a> et son <a href="https://github.com/etalab/csvapi-front/blob/exploration-table/src/views/AppCarburant.vue"><u>code source est libre.</u></a></i>
+                        <i>Cette visualisation a été créée par le département Etalab de <a href="https://www.numerique.gouv.fr/"><u>la Direction Interministérielle du Numérique (DINUM)</u></a> et son <a href="https://github.com/etalab/explore.data.gouv.fr/blob/main/src/views/AppCarburant.vue"><u>code source est libre.</u></a></i>
                       </div>
                       <br />
                     </div>


### PR DESCRIPTION
the link in description seems to be outdated, this modification should fix it